### PR TITLE
Update dawa-autocomplete.js

### DIFF
--- a/dawa-autocomplete.js
+++ b/dawa-autocomplete.js
@@ -1,7 +1,7 @@
 $.widget("dawa.dawaautocomplete", {
 	options: {
 		jsonp: !("withCredentials" in (new XMLHttpRequest())),
-		baseUrl: 'https://dawa.aws.dk',
+		baseUrl: '//dawa.aws.dk',
 		minLength: 2,
 		delay: 0,
 		adgangsadresserOnly: false,


### PR DESCRIPTION
The "http:" or the "https:" gives problems(the autocomplete doesn't work) if the user application uses the opposite protocol.
